### PR TITLE
Bump weasyprint from 61.2 to 64.0 in /code/lambdas/generate/requirements.txt

### DIFF
--- a/code/lambdas/generate/requirements.txt
+++ b/code/lambdas/generate/requirements.txt
@@ -1,4 +1,4 @@
-weasyprint==61.2
+weasyprint==64.0
 markdown==3.6
 aws-lambda-powertools[tracer,parser]==2.35.1
 boto3>=1.34.69


### PR DESCRIPTION
### Issue #4

### Description of Changes:
- Bump the `weasyprint` version from `61.2` to `64.0` in `/code/lambdas/generate/requirements.txt` to address compatibility issues with the PDF generation logic. This update resolves the error related to incorrect arguments being passed to the `PDF.__init__()` function.

### Confirmation:
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
